### PR TITLE
Fix types and allow emitEvent to handle async operations

### DIFF
--- a/src/AccountActivity/ActivityEmitter.ts
+++ b/src/AccountActivity/ActivityEmitter.ts
@@ -37,13 +37,14 @@ export class ActivityEmitter implements ActivityEmittable {
    */
   private readonly eventCallbacks: ActivityEmitCallback<ActivityEvent>[] = []
 
-  emitEvent(event: ActivityEvent): void {
-    const type = getEventType(event)
+  async emitEvent(event: ActivityEvent): Promise<void> {
+    await Promise.all(
+      this.callbacks
+        .filter((callback) => callback.type === getEventType(event))
+        .map(async (callback) => await callback.callback(event))
+    )
 
-    const callbacks = this.callbacks.filter((c) => c.type === type)
-    callbacks.forEach(({ callback }) => callback(event))
-
-    this.eventCallbacks.forEach((fn) => fn(event))
+    await Promise.all(this.eventCallbacks.map(async(fn) => await fn(event)))
   }
 
   onEvent(callback: ActivityEmitCallback<ActivityEvent>): void {

--- a/src/AccountActivity/WebhookHandler.ts
+++ b/src/AccountActivity/WebhookHandler.ts
@@ -36,8 +36,8 @@ export class WebhookHandler implements WebhookHandlable {
     }
   }
 
-  handle(body: ActivityEvent): void {
-    this.emitter.emitEvent(body)
+  async handle(body: ActivityEvent): Promise<void> {
+    await this.emitter.emitEvent(body)
   }
 
   installTo(app: Express, path: string): void {

--- a/src/AccountActivity/interfaces/ActivityEmittable.ts
+++ b/src/AccountActivity/interfaces/ActivityEmittable.ts
@@ -15,7 +15,7 @@ import {
 /**
  * ActivityEmitCallback type.
  */
-export type ActivityEmitCallback<T extends ActivityEvent> = (event: T) => void
+export type ActivityEmitCallback<T extends ActivityEvent> = (event: T) => Promise<void>
 
 /**
  * ActivityEmittable type.
@@ -26,7 +26,7 @@ export interface ActivityEmittable {
    *
    * @param event activity event.
    */
-  emitEvent(event: ActivityEvent): void
+  emitEvent(event: ActivityEvent): Promise<void>
 
   /**
    * add a callback for all activity events.

--- a/src/AccountActivity/interfaces/WebhookHandlable.ts
+++ b/src/AccountActivity/interfaces/WebhookHandlable.ts
@@ -23,7 +23,7 @@ export interface WebhookHandlable {
    *
    * @param body event body.
    */
-  handle(body: ActivityEvent): void
+  handle(body: ActivityEvent): Promise<void>
 
   /**
    * install handler to express app.

--- a/src/AccountActivity/types/Tweet.ts
+++ b/src/AccountActivity/types/Tweet.ts
@@ -19,16 +19,16 @@ export type Tweet = {
   text: string
   source: string
   truncated: boolean
-  in_reply_to_status_id?: number | null
-  in_reply_to_status_id_str?: string | null
-  in_reply_to_user_id?: number | null
-  in_reply_to_user_id_str?: string | null
-  in_reply_to_screen_name?: number | null
+  in_reply_to_status_id: number | null
+  in_reply_to_status_id_str: string | null
+  in_reply_to_user_id: number | null
+  in_reply_to_user_id_str: string | null
+  in_reply_to_screen_name: string | null
   user: User
-  geo?: Point | null
-  coordinates?: Point | null
-  place?: Place | null
-  contributors?: Contributor[] | null
+  geo: Point | null
+  coordinates: Point | null
+  place: Place | null
+  contributors: Contributor[] | null
   is_quote_status: boolean
   quote_count: number
   reply_count: number


### PR DESCRIPTION
@hota1024 As mentioned in #4, please review the PR.

Additionally, I think it's best if we eliminate `onEvent` and force users to use the other individual event handlers (e.g. `onTweetFavorite`) instead. I also propose we remove Express and allow users to implement it themselves if they really need it. This will keep the bundle size small when the library is added to their project. I have tried bundling my project with twict but even esbuild is having trouble tree-shaking the unused Express library out.